### PR TITLE
Adding Flip R&B and Shuffleboard

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,9 +7,6 @@ package frc.robot;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
-
-import java.io.File;
-
 import com.revrobotics.CANSparkBase.IdleMode;
 import edu.wpi.first.math.util.Units;
 
@@ -148,10 +145,5 @@ public final class Constants {
     public static final int kScissorLiftCanID = 11;
     public static final int kAcuatorCanID = 12;
     public static final int kRollerCanID = 13;
-  }
-
-  public static final class RecordPlaybackConstants {
-    public static final File kRecordDirectory = new File("/home/lvuser/Recordings");
-    public static final String kFileType = "txt";
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,6 +7,9 @@ package frc.robot;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
+
+import java.io.File;
+
 import com.revrobotics.CANSparkBase.IdleMode;
 import edu.wpi.first.math.util.Units;
 
@@ -145,5 +148,9 @@ public final class Constants {
     public static final int kScissorLiftCanID = 11;
     public static final int kAcuatorCanID = 12;
     public static final int kRollerCanID = 13;
+  }
+  public static final class RecordPlaybackConstants {
+    public static final File kRecordDirectory = new File("/home/lvuser/Recordings");
+    public static final String kFileType = "txt";
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,6 +7,9 @@ package frc.robot;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
+
+import java.io.File;
+
 import com.revrobotics.CANSparkBase.IdleMode;
 import edu.wpi.first.math.util.Units;
 
@@ -145,5 +148,10 @@ public final class Constants {
     public static final int kScissorLiftCanID = 11;
     public static final int kAcuatorCanID = 12;
     public static final int kRollerCanID = 13;
+  }
+
+  public static final class RecordPlaybackConstants {
+    public static final File kRecordDirectory = new File("/home/lvuser/Recordings");
+    public static final String kFileType = "txt";
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,7 @@ package frc.robot;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
+import frc.robot.Constants.RecordPlaybackConstants;
 import frc.robot.commands.AutoPickup;
 import frc.robot.commands.playBack;
 import frc.robot.commands.rec;
@@ -15,6 +16,7 @@ import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.VisionSerial;
 
+import java.io.File;
 import java.util.List;
 
 import edu.wpi.first.math.MathUtil;
@@ -26,11 +28,14 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
+import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SwerveControllerCommand;
@@ -49,11 +54,16 @@ public class RobotContainer {
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
   private final Onboarder onboarder = new Onboarder();
   private final Shooter shooter = new Shooter();
-  private ShuffleboardTab tab = Shuffleboard.getTab("Record and Playback");
   private String recFileName = "swerveRecord";
   // The driver's controller
   XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
   CommandXboxController commandController = new CommandXboxController(OIConstants.kDriverControllerPort);
+
+  // Shuffleboard
+  private final ShuffleboardTab tab = Shuffleboard.getTab("Autonomous");
+  private final SendableChooser<File> fileChooser = new SendableChooser<>();
+  private final GenericEntry fileName = tab.add("File Name", "")
+   .withWidget(BuiltInWidgets.kTextView).getEntry();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private rec recordCommand;
@@ -62,6 +72,16 @@ public class RobotContainer {
   //private IRBeamBreaker intakeSensor = new IRBeamBreaker(8);
 
   public RobotContainer() {
+    // Autonomous Shuffleboard Loader
+    File[] files = RecordPlaybackConstants.kRecordDirectory.listFiles();
+    for (int i = 0; i < files.length; i++) {
+      fileChooser.addOption(files[i].getName(), files[i]);
+    }
+    tab.add("Autonomous Mode", fileChooser)
+    .withWidget(BuiltInWidgets.kComboBoxChooser)
+    .withPosition(0, 0)
+    .withSize(2, 1);
+
     // Configure the trigger bindings
     configureBindings();
 
@@ -116,18 +136,14 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     
-    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, recFileName);
+    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, fileName);
 
     
     JoystickButton recButton = new JoystickButton(m_driverController, Button.kA.value);
     JoystickButton recButton2 = new JoystickButton(m_driverController, Button.kB.value);
     recButton.onTrue(recordCommand.until(recButton2));
 
-    JoystickButton flipPlayback = new JoystickButton(m_driverController, Button.kLeftBumper.value);
-    flipPlayback.onTrue(new RunCommand(() -> onRedAlliance = !onRedAlliance));
-    System.out.println(onRedAlliance);
-
-    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, tab, recFileName, onRedAlliance);
+    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, onRedAlliance);
     JoystickButton playBack = new JoystickButton(m_driverController, Button.kY.value);
     playBack.onTrue(playbackCommand);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -15,6 +15,7 @@ import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.VisionSerial;
 
+import java.io.File;
 import java.util.List;
 
 import edu.wpi.first.math.MathUtil;
@@ -26,11 +27,14 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
+import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SwerveControllerCommand;
@@ -49,11 +53,15 @@ public class RobotContainer {
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
   private final Onboarder onboarder = new Onboarder();
   private final Shooter shooter = new Shooter();
-  private ShuffleboardTab tab = Shuffleboard.getTab("Record and Playback");
-  private String recFileName = "swerveRecord";
   // The driver's controller
   XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
   CommandXboxController commandController = new CommandXboxController(OIConstants.kDriverControllerPort);
+
+  // Shuffleboard
+  private final ShuffleboardTab tab = Shuffleboard.getTab("Autonomous");
+  private final SendableChooser<File> fileChooser = new SendableChooser<>();
+  private final GenericEntry fileName = tab.add("File Name", "PLACEHOLDER")
+   .withWidget(BuiltInWidgets.kTextView).getEntry();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private rec recordCommand;
@@ -116,7 +124,7 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     
-    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, recFileName);
+    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, fileName);
 
     
     JoystickButton recButton = new JoystickButton(m_driverController, Button.kA.value);
@@ -127,7 +135,7 @@ public class RobotContainer {
     flipPlayback.onTrue(new RunCommand(() -> onRedAlliance = !onRedAlliance));
     System.out.println(onRedAlliance);
 
-    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, tab, recFileName, onRedAlliance);
+    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, onRedAlliance);
     JoystickButton playBack = new JoystickButton(m_driverController, Button.kY.value);
     playBack.onTrue(playbackCommand);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,7 +7,6 @@ package frc.robot;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
-import frc.robot.Constants.RecordPlaybackConstants;
 import frc.robot.commands.AutoPickup;
 import frc.robot.commands.playBack;
 import frc.robot.commands.rec;
@@ -16,7 +15,6 @@ import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.VisionSerial;
 
-import java.io.File;
 import java.util.List;
 
 import edu.wpi.first.math.MathUtil;
@@ -28,14 +26,11 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
-import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
-import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SwerveControllerCommand;
@@ -54,16 +49,11 @@ public class RobotContainer {
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
   private final Onboarder onboarder = new Onboarder();
   private final Shooter shooter = new Shooter();
+  private ShuffleboardTab tab = Shuffleboard.getTab("Record and Playback");
   private String recFileName = "swerveRecord";
   // The driver's controller
   XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
   CommandXboxController commandController = new CommandXboxController(OIConstants.kDriverControllerPort);
-
-  // Shuffleboard
-  private final ShuffleboardTab tab = Shuffleboard.getTab("Autonomous");
-  private final SendableChooser<File> fileChooser = new SendableChooser<>();
-  private final GenericEntry fileName = tab.add("File Name", "")
-   .withWidget(BuiltInWidgets.kTextView).getEntry();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private rec recordCommand;
@@ -72,16 +62,6 @@ public class RobotContainer {
   //private IRBeamBreaker intakeSensor = new IRBeamBreaker(8);
 
   public RobotContainer() {
-    // Autonomous Shuffleboard Loader
-    File[] files = RecordPlaybackConstants.kRecordDirectory.listFiles();
-    for (int i = 0; i < files.length; i++) {
-      fileChooser.addOption(files[i].getName(), files[i]);
-    }
-    tab.add("Autonomous Mode", fileChooser)
-    .withWidget(BuiltInWidgets.kComboBoxChooser)
-    .withPosition(0, 0)
-    .withSize(2, 1);
-
     // Configure the trigger bindings
     configureBindings();
 
@@ -136,14 +116,18 @@ public class RobotContainer {
             () -> m_robotDrive.setX(),
             m_robotDrive));
     
-    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, fileName);
+    recordCommand = new rec(m_robotDrive, onboarder, shooter, m_driverController, recFileName);
 
     
     JoystickButton recButton = new JoystickButton(m_driverController, Button.kA.value);
     JoystickButton recButton2 = new JoystickButton(m_driverController, Button.kB.value);
     recButton.onTrue(recordCommand.until(recButton2));
 
-    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, fileChooser, onRedAlliance);
+    JoystickButton flipPlayback = new JoystickButton(m_driverController, Button.kLeftBumper.value);
+    flipPlayback.onTrue(new RunCommand(() -> onRedAlliance = !onRedAlliance));
+    System.out.println(onRedAlliance);
+
+    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, tab, recFileName, onRedAlliance);
     JoystickButton playBack = new JoystickButton(m_driverController, Button.kY.value);
     playBack.onTrue(playbackCommand);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -57,7 +57,8 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private rec recordCommand;
-  private playBack playB = new playBack(m_robotDrive, onboarder, shooter, m_driverController, tab, recFileName);
+  private playBack playbackCommand;
+  private Boolean onRedAlliance = true;
   //private IRBeamBreaker intakeSensor = new IRBeamBreaker(8);
 
   public RobotContainer() {
@@ -122,13 +123,19 @@ public class RobotContainer {
     JoystickButton recButton2 = new JoystickButton(m_driverController, Button.kB.value);
     recButton.onTrue(recordCommand.until(recButton2));
 
+    JoystickButton flipPlayback = new JoystickButton(m_driverController, Button.kLeftBumper.value);
+    flipPlayback.onTrue(new RunCommand(() -> onRedAlliance = !onRedAlliance));
+    System.out.println(onRedAlliance);
+
+    playbackCommand = new playBack(m_robotDrive, onboarder, shooter, m_driverController, tab, recFileName, onRedAlliance);
     JoystickButton playBack = new JoystickButton(m_driverController, Button.kY.value);
-    playBack.onTrue(playB);
+    playBack.onTrue(playbackCommand);
 
 
     new JoystickButton(m_driverController, Button.kStart.value)
        .whileTrue(new RunCommand(
-           () -> m_robotDrive.resetGyro()));
+          () -> m_robotDrive.resetGyro()
+        ));
   }
 
   /**

--- a/src/main/java/frc/robot/commands/playBack.java
+++ b/src/main/java/frc/robot/commands/playBack.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.shuffleboard.SimpleWidget;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -26,10 +27,8 @@ public class playBack extends CommandBase {
   private DriveSubsystem swerveController;
   private Onboarder onboarder;
   private Shooter shooter;
-  private ShuffleboardTab tab;
-  private GenericEntry textbox;
-  private String recFileName;
   private Boolean onRed = false;
+  private SendableChooser<File> recSelector;
 
   private double controlLeftY;
   private double controlLeftX;
@@ -39,31 +38,26 @@ public class playBack extends CommandBase {
 
   private File rFile;
   private Scanner sc;
-  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, ShuffleboardTab tab, String recFileNameParam, Boolean onRed) {
+  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, SendableChooser<File> RecSelector, Boolean onRed) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.swerveController = swerveController;
     this.onboarder = onboarder;
     this.shooter = shooter;
+
+    this.recSelector = RecSelector;
     this.onRed = onRed;
-
-    this.recFileName = recFileNameParam;
-
-
-
-    this.tab = tab;
-    textbox = tab.add("Recording", "default value")
-      .withWidget(BuiltInWidgets.kTextView).getEntry();
-    addRequirements(swerveController, onboarder);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     try {
-      rFile = new File("/home/lvuser/" + recFileName + ".txt");
+      rFile = new File(recSelector.getSelected().toString());
       sc = new Scanner(rFile);
+      System.out.println("Playback Started with: " + recSelector.getSelected());
+
     } catch (IOException e) {
-     //System.out.println("An error occurred.");
+      System.out.println("Failed to read file: ");
       e.printStackTrace();
     }
   }
@@ -80,7 +74,7 @@ public class playBack extends CommandBase {
     shooterSpeed = Double.valueOf(currentArray[4]);
 
     if (onRed) {
-      //controlLeftY *= 1;
+      //controlLeftY *= 1; F&B
       controlLeftX *= -1;
       controlRightX *= -1;
     }
@@ -103,7 +97,10 @@ public class playBack extends CommandBase {
       0,
       0,
       0,
-      true, true);
+      true, true
+    );
+    onboarder.setSpeed(0);
+    shooter.shoot(0);
   }
   
 

--- a/src/main/java/frc/robot/commands/playBack.java
+++ b/src/main/java/frc/robot/commands/playBack.java
@@ -4,19 +4,27 @@
 
 package frc.robot.commands;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.util.Map;
 import java.util.Scanner;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.shuffleboard.SimpleWidget;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.Constants.RecordPlaybackConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
@@ -24,60 +32,68 @@ import frc.robot.subsystems.Shooter;
 public class playBack extends CommandBase {
   /** Creates a new playBack. */
   private DriveSubsystem swerveController;
+  private boolean isFinished;
   private Onboarder onboarder;
   private Shooter shooter;
-  private ShuffleboardTab tab;
-  private GenericEntry textbox;
-  private String recFileName;
   private Boolean onRed = false;
 
+  private FileInputStream fileInput;
+  private BufferedInputStream bufferedInput;
+  private ObjectInputStream objectInput;
+  private SendableChooser<File> recSelector;
+
+  private double[] data;
   private double controlLeftY;
   private double controlLeftX;
   private double controlRightX;
   private double onboarderSpeed;
   private double shooterSpeed;
 
-  private File rFile;
-  private Scanner sc;
-  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, ShuffleboardTab tab, String recFileNameParam, Boolean onRed) {
+  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, SendableChooser<File> RecSelector, Boolean onRed) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.swerveController = swerveController;
     this.onboarder = onboarder;
     this.shooter = shooter;
+
+    this.recSelector = RecSelector;
     this.onRed = onRed;
-
-    this.recFileName = recFileNameParam;
-
-
-
-    this.tab = tab;
-    textbox = tab.add("Recording", "default value")
-      .withWidget(BuiltInWidgets.kTextView).getEntry();
-    addRequirements(swerveController, onboarder);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    try {
-      rFile = new File("/home/lvuser/" + recFileName + ".txt");
-      sc = new Scanner(rFile);
-    } catch (IOException e) {
-     //System.out.println("An error occurred.");
-      e.printStackTrace();
-    }
+      isFinished = false;
+      try {
+          fileInput = new FileInputStream(recSelector.getSelected()); //File output stream
+          bufferedInput = new BufferedInputStream(fileInput); // buffer output
+          objectInput = new ObjectInputStream(bufferedInput); // object output
+          System.out.println("Playback Started with: " + recSelector.getSelected());
+        
+        } catch (IOException e) {
+          System.out.println("Failed to read file: ");
+          e.printStackTrace();
+      }
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    String cLine = sc.nextLine();
-    String[] currentArray = cLine.split(",", 6);
-    controlLeftY = Double.valueOf(currentArray[0]);
-    controlLeftX = Double.valueOf(currentArray[1]);
-    controlRightX = Double.valueOf(currentArray[2]);
-    onboarderSpeed = Double.valueOf(currentArray[3]);
-    shooterSpeed = Double.valueOf(currentArray[4]);
+    try {
+      data = (double[]) objectInput.readObject();
+      if (!(objectInput.available() > 0)) {
+        isFinished = true;
+      }
+    } catch (Exception e) {
+      isFinished = true;
+      System.out.println("Failed to playback: ");
+      e.printStackTrace();
+    }
+
+    controlLeftY = data[0];
+    controlLeftX = data[1];
+    controlRightX = data[2];
+    onboarderSpeed = data[3];
+    shooterSpeed = data[3];
 
     if (onRed) {
       //controlLeftY *= 1;
@@ -98,22 +114,41 @@ public class playBack extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    sc.close();
+    try {
+      objectInput.close();
+      bufferedInput.close();
+      fileInput.close();
+    } catch (IOException e) {
+      System.out.println("Failed to end playback: ");
+      e.printStackTrace();
+    }
+  
     this.swerveController.drive(
       0,
       0,
       0,
-      true, true);
+      true, true
+    );
+    onboarder.setSpeed(0);
+    shooter.shoot(0);
   }
   
 
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    if (sc.hasNextLine()) {
-      return false;
-    } else {
+    /*
+    try {
+      if (!(objectInput.available() > 0)) {
+        return true;
+      } else {
+        return false;
+      }
+      
+    } catch (Exception e) {
       return true;
     }
+    */
+    return isFinished;
   }
 }

--- a/src/main/java/frc/robot/commands/playBack.java
+++ b/src/main/java/frc/robot/commands/playBack.java
@@ -29,6 +29,7 @@ public class playBack extends CommandBase {
   private ShuffleboardTab tab;
   private GenericEntry textbox;
   private String recFileName;
+  private Boolean onRed = false;
 
   private double controlLeftY;
   private double controlLeftX;
@@ -38,11 +39,12 @@ public class playBack extends CommandBase {
 
   private File rFile;
   private Scanner sc;
-  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, ShuffleboardTab tab, String recFileNameParam) {
+  public playBack(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, ShuffleboardTab tab, String recFileNameParam, Boolean onRed) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.swerveController = swerveController;
     this.onboarder = onboarder;
     this.shooter = shooter;
+    this.onRed = onRed;
 
     this.recFileName = recFileNameParam;
 
@@ -77,6 +79,12 @@ public class playBack extends CommandBase {
     onboarderSpeed = Double.valueOf(currentArray[3]);
     shooterSpeed = Double.valueOf(currentArray[4]);
 
+    if (onRed) {
+      //controlLeftY *= 1;
+      controlLeftX *= -1;
+      controlRightX *= -1;
+    }
+
     this.swerveController.drive(
       controlLeftY,
       controlLeftX,
@@ -92,12 +100,12 @@ public class playBack extends CommandBase {
   public void end(boolean interrupted) {
     sc.close();
     this.swerveController.drive(
-      controlLeftY,
-      controlLeftX,
-      controlRightX,
+      0,
+      0,
+      0,
       true, true);
-    //new SequentialCommandGroup(new AutoBTimed(playControl)).schedule();
   }
+  
 
   // Returns true when the command should end.
   @Override

--- a/src/main/java/frc/robot/commands/rec.java
+++ b/src/main/java/frc/robot/commands/rec.java
@@ -4,29 +4,20 @@
 
 package frc.robot.commands;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
-import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import frc.robot.Constants.OIConstants;
-import frc.robot.Constants.RecordPlaybackConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class rec extends CommandBase {
@@ -35,14 +26,9 @@ public class rec extends CommandBase {
   private Onboarder onboarder;
   private Shooter shooter;
   private XboxController controller;
-
-  private FileOutputStream fileOutput;
-  private BufferedOutputStream bufferedOutput;
-  private ObjectOutputStream objectOutput;
-  private SendableChooser<File> RecSelector;
-  private GenericEntry recFileName;
-  private File recordFile;
-  private int fileCount = 0;
+  private String recFile;
+  private String recFileName;
+  private FileWriter rFile;
 
   private double controlLeftY;
   private double controlLeftX;
@@ -50,16 +36,14 @@ public class rec extends CommandBase {
   private double onboarderSpeed;
   private double shooterSpeed;
 
-  public rec(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, SendableChooser<File> RecSelector, GenericEntry FileName) {
+  public rec(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, String recFileNameParam) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.swerveController = swerveController;
     this.onboarder = onboarder;
     this.shooter = shooter;
 
-    this.RecSelector = RecSelector;
-    this.recFileName = FileName;
-
     this.controller = controller;
+    this.recFileName = recFileNameParam;
     //this.name = name;
     addRequirements(swerveController);
   }
@@ -67,17 +51,17 @@ public class rec extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-      try {
-          recordFile = new File(RecordPlaybackConstants.kRecordDirectory,recFileName.getString("rec"+fileCount)+"."+RecordPlaybackConstants.kFileType);
-          fileOutput = new FileOutputStream(recordFile); //File output stream
-          bufferedOutput = new BufferedOutputStream(fileOutput); // buffer output
-          objectOutput = new ObjectOutputStream(bufferedOutput); // object output
-          System.out.println("Recording at: " + recordFile);
-        
+    recFile = "/home/lvuser/" + recFileName + ".txt";
+    try {
+          File prevFile = new File(recFile);
+          prevFile.delete();
+          rFile = new FileWriter(recFile);
+         //System.out.println("File created: " + rFile);
+          
         } catch (IOException e) {
-          System.out.println("Failed to create file: ");
+         //System.out.println("An error occurred.");
           e.printStackTrace();
-      }
+    }
     }
 
 
@@ -87,15 +71,13 @@ public class rec extends CommandBase {
     controlLeftY = -MathUtil.applyDeadband(controller.getLeftY() * -.5, OIConstants.kDriveDeadband);
     controlLeftX = -MathUtil.applyDeadband(controller.getLeftX() * -.5, OIConstants.kDriveDeadband);
     controlRightX = -MathUtil.applyDeadband(controller.getRightX() * -.5, OIConstants.kDriveDeadband);
+
     onboarderSpeed = onboarder.getSpeed();
     shooterSpeed = shooter.getSpeed();
-
-    double[] recordData = {controlLeftY, controlLeftX, controlRightX, onboarderSpeed, shooterSpeed};
-
     try {
-      objectOutput.writeObject(recordData);
+      rFile.append(String.valueOf(controlLeftY) + "," + String.valueOf(controlLeftX) + "," + String.valueOf(controlRightX) + "," + String.valueOf(onboarderSpeed) + "," + String.valueOf(shooterSpeed) + "," + "\n");
     } catch (IOException e) {
-      System.out.println("Failed to start record: ");
+     //System.out.println("An error occurred.");
       e.printStackTrace();
     }
     this.swerveController.drive(
@@ -109,16 +91,11 @@ public class rec extends CommandBase {
   @Override
   public void end(boolean interrupted) {
     try {
-      objectOutput.close();
-      bufferedOutput.close();
-      fileOutput.close();
+      rFile.close();
     } catch (IOException e) {
-      System.out.println("Failed to end record: ");
+     //System.out.println("An error occurred.");
       e.printStackTrace();
     }
-
-    RecSelector.addOption(recordFile.getName(), recordFile);
-    fileCount++;
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/rec.java
+++ b/src/main/java/frc/robot/commands/rec.java
@@ -9,15 +9,18 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import frc.robot.Constants.OIConstants;
+import frc.robot.Constants.RecordPlaybackConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.Onboarder;
 import frc.robot.subsystems.Shooter;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class rec extends CommandBase {
@@ -26,9 +29,12 @@ public class rec extends CommandBase {
   private Onboarder onboarder;
   private Shooter shooter;
   private XboxController controller;
-  private String recFile;
-  private String recFileName;
+
   private FileWriter rFile;
+  private SendableChooser<File> RecSelector;
+  private GenericEntry recFileName;
+  private File recordFile;
+  private int fileCount = 0;
 
   private double controlLeftY;
   private double controlLeftX;
@@ -36,32 +42,30 @@ public class rec extends CommandBase {
   private double onboarderSpeed;
   private double shooterSpeed;
 
-  public rec(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, String recFileNameParam) {
+  public rec(DriveSubsystem swerveController, Onboarder onboarder, Shooter shooter, XboxController controller, SendableChooser<File> RecSelector, GenericEntry FileName) {
     // Use addRequirements() here to declare subsystem dependencies.
     this.swerveController = swerveController;
     this.onboarder = onboarder;
     this.shooter = shooter;
 
     this.controller = controller;
-    this.recFileName = recFileNameParam;
-    //this.name = name;
+    
+    this.RecSelector = RecSelector;
+    this.recFileName = FileName;
     addRequirements(swerveController);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    recFile = "/home/lvuser/" + recFileName + ".txt";
-    try {
-          File prevFile = new File(recFile);
-          prevFile.delete();
-          rFile = new FileWriter(recFile);
-         //System.out.println("File created: " + rFile);
-          
+      try {
+          recordFile = new File(RecordPlaybackConstants.kRecordDirectory,recFileName.getString("rec"+fileCount)+"."+RecordPlaybackConstants.kFileType);
+          rFile = new FileWriter(recordFile);
+          System.out.println("Recording at: " + recordFile);
         } catch (IOException e) {
-         //System.out.println("An error occurred.");
+          System.out.println("Failed to create file: ");
           e.printStackTrace();
-    }
+      }
     }
 
 
@@ -75,7 +79,14 @@ public class rec extends CommandBase {
     onboarderSpeed = onboarder.getSpeed();
     shooterSpeed = shooter.getSpeed();
     try {
-      rFile.append(String.valueOf(controlLeftY) + "," + String.valueOf(controlLeftX) + "," + String.valueOf(controlRightX) + "," + String.valueOf(onboarderSpeed) + "," + String.valueOf(shooterSpeed) + "," + "\n");
+      rFile.append(
+        String.valueOf(controlLeftY) + "," +
+        String.valueOf(controlLeftX) + "," +
+        String.valueOf(controlRightX) + "," +
+        String.valueOf(onboarderSpeed) + "," +
+        String.valueOf(shooterSpeed) + "," +
+        "\n"
+      );
     } catch (IOException e) {
      //System.out.println("An error occurred.");
       e.printStackTrace();
@@ -84,7 +95,8 @@ public class rec extends CommandBase {
       controlLeftY,
       controlLeftX,
       controlRightX,
-      true, true);
+      true, true
+    );
   }
 
   // Called once the command ends or is interrupted.
@@ -93,9 +105,10 @@ public class rec extends CommandBase {
     try {
       rFile.close();
     } catch (IOException e) {
-     //System.out.println("An error occurred.");
+      System.out.println("Failed to end record: ");
       e.printStackTrace();
     }
+    fileCount++;
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/rec.java
+++ b/src/main/java/frc/robot/commands/rec.java
@@ -4,6 +4,7 @@
 
 package frc.robot.commands;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
@@ -52,6 +53,8 @@ public class rec extends CommandBase {
   public void initialize() {
     recFile = "/home/lvuser/" + recFileName + ".txt";
     try {
+          File prevFile = new File(recFile);
+          prevFile.delete();
           rFile = new FileWriter(recFile);
          //System.out.println("File created: " + rFile);
           

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -88,8 +88,8 @@ public class DriveSubsystem extends SubsystemBase {
             m_rearRight.getPosition()
         });
     SmartDashboard.putNumber("Gyro Angle", -m_gyro.getAngle());
-    System.out.println("FL: " + m_frontLeft.getPosition()+ " FR: "+m_frontRight.getPosition());
-    System.out.println("BL: "+m_rearLeft.getPosition()+" BR: "+m_rearRight.getPosition());
+    //System.out.println("FL: " + m_frontLeft.getPosition()+ " FR: "+m_frontRight.getPosition());
+    //System.out.println("BL: "+m_rearLeft.getPosition()+" BR: "+m_rearRight.getPosition());
     //SmartDashboard.putNumber("Rear Left Module", m_rearLeft.getPosition());
   }
 


### PR DESCRIPTION
Added the flip feature for Record and playback to be used when changing alliances. Should speed up autonomous creations. Also added file creation and selection in Shuffleboard, autonomous files can now be selected with dropdown in Shuffleboard.

Reverted a commit that contained a change for record and playback reading. This commit reads the file with a buffer and changed the format of readind/writing to the record file. Reverted due to already existing and working code. Set as a tagged commit for future use if necessary.

Also fixed error messages to be more readable and added constants for R&B file locations and type. Cleaned up both files for readablility.